### PR TITLE
Make benchmarks easier to use. Fix #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ See an example in `uix.recipes.server-rendering`
 
 ## Benchmarks
 
-- Hiccup interpretation `clojure -A:dev:benchmark -m figwheel.main -O advanced -bo benchmark`
-- SSR on JVM `clojure -A:dev:benchmark -m uix.benchmark`
+- Hiccup interpretation `clojure -A:dev:benchmark:bench-front`
+- SSR on JVM `clojure -A:dev:benchmark:bench-ssr`
 
 ### Hiccup interpretation
 

--- a/benchmark.cljs.edn
+++ b/benchmark.cljs.edn
@@ -1,3 +1,4 @@
+^{:open-url "http://localhost:[[server-port]]/benchmark.html"}
 {:output-dir "resources/public/out"
  :output-to "resources/public/out/benchmark.js"
  :asset-path "out"

--- a/deps.edn
+++ b/deps.edn
@@ -15,13 +15,15 @@
                               cljfmt {:mvn/version "0.6.4"}}}
            :rec-front {:extra-deps {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
                        :main-opts ["-m" "figwheel.main" "--build" "dev" "--repl" "--serve"]}
-           :rec-back  {:main-opts ["-m" "uix.recipes.server-rendering"]}
+           :rec-ssr  {:main-opts ["-m" "uix.recipes.server-rendering"]}
            :benchmark {:extra-paths ["benchmark"]
                        :extra-deps {reagent {:mvn/version "0.9.0-SNAPSHOT"}
                                     criterium {:mvn/version "0.4.5"}
                                     enlive {:mvn/version "1.1.6"}
                                     hiccup {:mvn/version "1.0.5"}
                                     rum {:mvn/version "0.11.2"}}}
+           :bench-front {:main-opts ["-m" "figwheel.main" "-O" "advanced" "--build" "benchmark" "--serve"]}
+           :bench-ssr {:main-opts ["-m" "uix.benchmark"]}
            :test {:extra-paths ["test"]}
            :ci {:extra-paths ["dev"]
                 :extra-deps {cljfmt {:mvn/version "0.6.4"}}}}}


### PR DESCRIPTION
I used [this Figwheel feature](https://figwheel.org/docs/your_own_page.html#using-a-page-other-than-server-root) to enable serving benchmark.html after building the code. You can use any optim level, it's unrelated.