### PR TITLE
Fix effect and layout-effect hook dependency handling

### DIFF
--- a/core/src/uix/hooks/alpha.cljc
+++ b/core/src/uix/hooks/alpha.cljc
@@ -145,7 +145,7 @@
      (let [[deps setup-fn] (if (vector? deps)
                              [deps body]
                              [nil (cons deps body)])]
-       `(effect! #(do ~@setup-fn) (maybe-js-deps ~deps)))))
+       `(effect! #(do ~@setup-fn) ~deps))))
 
 ;; == Layout effect hook ==
 (defn layout-effect!
@@ -173,7 +173,7 @@
      (let [[deps setup-fn] (if (vector? deps)
                              [deps body]
                              [nil (cons deps body)])]
-       `(layout-effect! #(do ~@setup-fn) (maybe-js-deps ~deps)))))
+       `(layout-effect! #(do ~@setup-fn) ~deps))))
 
 ;; == Callback hook ==
 (defn callback

--- a/core/src/uix/hooks/alpha.cljc
+++ b/core/src/uix/hooks/alpha.cljc
@@ -134,7 +134,7 @@
                  (reset! prev-deps* deps)
                  (let [ret (setup-fn)]
                    (if (fn? ret) ret js/undefined)))
-               (maybe-deps @prev-deps*))
+               (maybe-js-deps @prev-deps*))
               deps)
       :clj nil)))
 
@@ -162,7 +162,7 @@
                  (reset! prev-deps* deps)
                  (let [ret (setup-fn)]
                    (if (fn? ret) ret js/undefined)))
-               (maybe-deps @prev-deps*))
+               (maybe-js-deps @prev-deps*))
               deps)
       :clj nil)))
 


### PR DESCRIPTION
There is an issue that causes effects and layout effects to render each time even if the dependencies haven't changed. The `with-layout-effect` and `with-effect` helper macros were calling `maybe-js-deps` on the dependencies which was turning them into an Javascript array.

This caused the Clojure-friendly dependency checking (with refs) in `effect!` and `layout-effect!` to detect that the dependencies changed each time since it was doing a `not=` comparison on two Javascript arrays, which always returns true unless the arrays are identical.

The fix is to pass the dependencies as-is to the underlying `effect!` and `layout-effect!` functions which will do their own processing of them.

The other change I made was to use `maybe-js-deps` in `effect!` and `layout-effect!` to convert dependencies into Javascript arrays before passing them to `react/useEffect` and `react/useLayoutEffect`. I don't know if this is strictly necessary, but since `react/useEffect` and `react/useLayoutEffect` are Javascript functions it seems more clear to convert the dependencies to a JS array.