### PR TITLE
use cljs.core/demunge instead of our replacement

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -336,17 +336,8 @@
 (defn react-type? [t]
   (or (lazy? t) (memo? t)))
 
-(def fmt-dash-regex (js/RegExp. "_" "g"))
-(def fmt-qmark-regex (js/RegExp. "_QMARK_" "g"))
-(def fmt-bang-regex (js/RegExp. "_BANG_" "g"))
-(def fmt-star-regex (js/RegExp. "_STAR_" "g"))
-
 (defn ^string demunge-name [^string s]
-  (-> s
-      (.replace fmt-qmark-regex "?")
-      (.replace fmt-bang-regex "!")
-      (.replace fmt-star-regex "*")
-      (.replace fmt-dash-regex "-")))
+  (demunge s))
 
 (defn format-display-name [^string s]
   (let [^js/Array parts (.split s #"\$")


### PR DESCRIPTION
I want to see properly demunged component names in React Devtools.
e.g. I had problem with `_LT_` and `_GT_`

cljs has full list here:
https://github.com/clojure/clojurescript/blob/79c1e828449cbb8c354fdd5ec0d999a5424249d3/src/main/cljs/cljs/core.cljs#L362-L387