### PR TITLE
Quoted keys

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -41,25 +41,11 @@
 (defn add-transform-fn [f]
   (swap! transform-fns conj f))
 
-(defn ^string capitalize [^string s]
-  (if (< (.-length s) 2)
-    (str/upper-case s)
-    (str ^string (str/upper-case (subs s 0 1)) ^string (subs s 1))))
-
 (defn ^string dash-to-camel [dashed]
-  (let [name-str (-name dashed)
-        parts (.split name-str #"-")
-        ^string start (aget parts 0)
-        parts (.slice parts 1)]
-    (if (or (= start "aria") (= start "data"))
+  (let [name-str (-name dashed)]
+    (if (re-matches #"^(aria-|data-).*" name-str)
       name-str
-      (str start (-> parts
-                     (array-reduce
-                       (fn [a p]
-                         (.push a (capitalize p))
-                         a)
-                       #js [])
-                     ^string (.join ""))))))
+      (str/replace name-str #"-(\w)" #(str/upper-case (second %))))))
 
 (defn cached-prop-name [k]
   (if (named? k)

--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -43,9 +43,10 @@
 
 (defn ^string dash-to-camel [dashed]
   (let [name-str (-name dashed)]
-    (if (re-matches #"^(aria-|data-).*" name-str)
-      name-str
-      (str/replace name-str #"-(\w)" #(str/upper-case (second %))))))
+    (cond
+      (some? (re-matches #"^(aria-|data-).*" name-str)) name-str
+      (= (subs name-str 0 1) "'") (subs name-str 1)
+      :else (str/replace name-str #"-(\w)" #(str/upper-case (second %))))))
 
 (defn cached-prop-name [k]
   (if (named? k)

--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -42,11 +42,13 @@
   (swap! transform-fns conj f))
 
 (defn ^string dash-to-camel [dashed]
-  (let [name-str (-name dashed)]
-    (cond
-      (some? (re-matches #"^(aria-|data-).*" name-str)) name-str
-      (= (subs name-str 0 1) "'") (subs name-str 1)
-      :else (str/replace name-str #"-(\w)" #(str/upper-case (second %))))))
+  (if (string? dashed)
+    dashed
+    (let [name-str (-name dashed)]
+      (cond
+        (some? (re-matches #"^(aria-|data-).*" name-str)) name-str
+        (= (subs name-str 0 1) "'") (subs name-str 1)
+        :else (str/replace name-str #"-(\w)" #(str/upper-case (second %)))))))
 
 (defn cached-prop-name [k]
   (if (named? k)

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -128,6 +128,11 @@
                     'name1-name2-name3 "name1Name2Name3"
                     'data-name "data-name"
                     'aria-name "aria-name"
+                    ; strings
+                    "key" "key"
+                    "name1-name2-name3" "name1-name2-name3"
+                    "data-name" "data-name"
+                    "aria-name" "aria-name"
                     ; quoting
                     :'name1-name2-name3 "name1-name2-name3"
                     (symbol "'name1-name2-name3") "name1-name2-name3"))

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -1,5 +1,5 @@
 (ns uix.compiler-test
-  (:require [clojure.test :refer [deftest is testing run-tests]]
+  (:require [clojure.test :refer [deftest is are testing run-tests]]
             [uix.compiler.alpha :as uixc]
             [uix.test-utils :refer [as-string js-equal? with-error symbol-for]]))
 
@@ -115,6 +115,17 @@
 (deftest test-add-transform-fn
   (uixc/add-transform-fn identity)
   (is (= @uixc/transform-fns #{identity})))
+
+(deftest test-dash-to-camel
+  (are [dash camel] (= (uixc/dash-to-camel dash) camel)
+                    :key "key"
+                    :name1-name2-name3 "name1Name2Name3"
+                    :data-name "data-name"
+                    :aria-name "aria-name"
+                    'key "key"
+                    'name1-name2-name3 "name1Name2Name3"
+                    'data-name "data-name"
+                    'aria-name "aria-name"))
 
 (deftest cached-prop-name
   (is (= "className" (uixc/cached-prop-name :class))))

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -118,14 +118,19 @@
 
 (deftest test-dash-to-camel
   (are [dash camel] (= (uixc/dash-to-camel dash) camel)
+                    ; keywords
                     :key "key"
                     :name1-name2-name3 "name1Name2Name3"
                     :data-name "data-name"
                     :aria-name "aria-name"
+                    ; symbols
                     'key "key"
                     'name1-name2-name3 "name1Name2Name3"
                     'data-name "data-name"
-                    'aria-name "aria-name"))
+                    'aria-name "aria-name"
+                    ; quoting
+                    :'name1-name2-name3 "name1-name2-name3"
+                    (symbol "'name1-name2-name3") "name1-name2-name3"))
 
 (deftest cached-prop-name
   (is (= "className" (uixc/cached-prop-name :class))))


### PR DESCRIPTION
I bounced into cases where automatic camelcase conversion of keys is not desirable[1]. And I needed to opt-out on key-by-key basis. This PR introduces possibility to quote keyword (or symbol) to prevent camelcase conversion. See the tests for example.

I looked at the code and while I was at it I added tests and (hopefully) improved dash-to-camel complexity.

I noticed that string keys are not handled gracefully because strings don't implment `-name` protocol (at least not in cljs). Another solution for my issue would be to allow string keys and take them literally without any conversion. I didn't want to introduce this at this point (maybe you had a reason not supporting string keys?). Quoting of currently allowed keys still makes sense if a library user want to stick to only one style of writing keys but needs to opt-out occasionaly (my case). Allowing string keys can be discussed as a separate issue.

[1] react-three-fiber (or JSX?) uses dashes for walking deeper into object hierarchy (dash translates to dot property access):
https://github.com/react-spring/react-three-fiber/blob/534fe1aaa63d27dcf65f43d05566977df759eef1/examples/src/demos/Montage.js#L54-L55