### PR TITLE
Fix missing docstring

### DIFF
--- a/core/src/uix/core/alpha.cljc
+++ b/core/src/uix/core/alpha.cljc
@@ -273,8 +273,9 @@
        `(defn ~sym ~args
           (uixr/compile-defui ~sym ~body)))))
 
-(defn as-element [x]
+(defn as-element
   "Compiles Hiccup into React elements at run-time."
+  [x]
   #?(:cljs (compiler/as-element x)
      :clj x))
 


### PR DESCRIPTION
Docstrings must appear before the `argslist`.

Fixes #52 