### PR TITLE
Fix devtools check

### DIFF
--- a/core/src/xframe/core/alpha.cljc
+++ b/core/src/xframe/core/alpha.cljc
@@ -20,7 +20,7 @@
   db +====> A +====> B +====> [B]
    +
    +---> C +---> D
-  
+
   Alternatives:
   - https://github.com/salsa-rs/salsa"
   #?(:cljs (:require-macros [xframe.core.alpha :refer [reg-sub]]))
@@ -124,7 +124,7 @@
                ~get-state-sym #(<- ~s-sym k#)]
            ~(if (uix.lib/cljs-env? &env)
               `(if ~(with-meta 'goog.DEBUG {:tag 'boolean})
-                 (if (and ~'js/__REACT_DEVTOOLS_GLOBAL_HOOK__
+                 (if (and (some? js/window.__REACT_DEVTOOLS_GLOBAL_HOOK__)
                           (-> (.. ~'js/__REACT_DEVTOOLS_GLOBAL_HOOK__ -renderers) (.get 1) .getCurrentFiber))
                    ~ret
                    (~get-state-sym))

--- a/core/src/xframe/core/alpha.cljc
+++ b/core/src/xframe/core/alpha.cljc
@@ -124,7 +124,7 @@
                ~get-state-sym #(<- ~s-sym k#)]
            ~(if (uix.lib/cljs-env? &env)
               `(if ~(with-meta 'goog.DEBUG {:tag 'boolean})
-                 (if (and (exists? ~'js/__REACT_DEVTOOLS_GLOBAL_HOOK__)
+                 (if (and ~'(exists? js/__REACT_DEVTOOLS_GLOBAL_HOOK__)
                           (-> (.. ~'js/__REACT_DEVTOOLS_GLOBAL_HOOK__ -renderers) (.get 1) .getCurrentFiber))
                    ~ret
                    (~get-state-sym))

--- a/core/src/xframe/core/alpha.cljc
+++ b/core/src/xframe/core/alpha.cljc
@@ -124,7 +124,7 @@
                ~get-state-sym #(<- ~s-sym k#)]
            ~(if (uix.lib/cljs-env? &env)
               `(if ~(with-meta 'goog.DEBUG {:tag 'boolean})
-                 (if (and (some? (.-__REACT_DEVTOOLS_GLOBAL_HOOK__ goog.global))
+                 (if (and (exists? ~'js/__REACT_DEVTOOLS_GLOBAL_HOOK__)
                           (-> (.. ~'js/__REACT_DEVTOOLS_GLOBAL_HOOK__ -renderers) (.get 1) .getCurrentFiber))
                    ~ret
                    (~get-state-sym))

--- a/core/src/xframe/core/alpha.cljc
+++ b/core/src/xframe/core/alpha.cljc
@@ -124,7 +124,7 @@
                ~get-state-sym #(<- ~s-sym k#)]
            ~(if (uix.lib/cljs-env? &env)
               `(if ~(with-meta 'goog.DEBUG {:tag 'boolean})
-                 (if (and (some? js/window.__REACT_DEVTOOLS_GLOBAL_HOOK__)
+                 (if (and (some? (.-__REACT_DEVTOOLS_GLOBAL_HOOK__ goog.global))
                           (-> (.. ~'js/__REACT_DEVTOOLS_GLOBAL_HOOK__ -renderers) (.get 1) .getCurrentFiber))
                    ~ret
                    (~get-state-sym))


### PR DESCRIPTION
@codeasone @roman01la fix of #50 

I think in #50 `exists?` was blowing up the clojure reader.
cljs-compiler on usage of `xframe.core/<sub` resulted in:

```
  15 | (defn lookup-sub [id]
  16 |   #?(:cljs (xf/<sub [:get id])
------------------^-------------------------------------------------------------
 Use of undeclared Var xframe.core.alpha/exists?
```

Previously the macro expanded to
```
(xframe.core.alpha/exists? js/__REACT_DEVTOOLS_GLOBAL_HOOK__)
```

As of this PR it properly expands to
```
(exists? js/__REACT_DEVTOOLS_GLOBAL_HOOK__)
```

Tested with `:optimizations :none`.

Thanks for not eagerly merging @roman01la!