### PR TITLE
fix: return value for `reset!` + `swap!` in state

### DIFF
--- a/core/src/uix/hooks/alpha.cljc
+++ b/core/src/uix/hooks/alpha.cljc
@@ -21,17 +21,18 @@
 
      IReset
      (-reset! [o new-value]
-       (set-value new-value))
+       (set-value new-value)
+       new-value)
 
      ISwap
      (-swap! [o f]
-       (set-value f))
+       (-reset! o (f (-deref o))))
      (-swap! [o f a]
-       (set-value #(f % a)))
+       (-reset! o (f (-deref o) a)))
      (-swap! [o f a b]
-       (set-value #(f % a b)))
+       (-reset! o (f (-deref o) a b)))
      (-swap! [o f a b xs]
-       (set-value #(apply f % a b xs)))
+       (-reset! o (apply f (-deref o) a b xs)))
 
      IPrintWithWriter
      (-pr-writer [o writer opts]
@@ -259,7 +260,7 @@
 
      IReset
      (-reset! [o new-value]
-       (swap! ref update-in path (constantly new-value)))
+       (get-in (swap! ref update-in path (constantly new-value)) path))
 
      ISwap
      (-swap! [o f]

--- a/core/test/uix/hooks_test.cljs
+++ b/core/test/uix/hooks_test.cljs
@@ -15,7 +15,7 @@
                     (is (or (== @state 1) (== @state 2)))
                     (if (== @state 2)
                       (done)
-                      (swap! state inc))))]
+                      (is (== 2 (swap! state inc))))))]
     (async done
       (t/render [f-state done]))))
 
@@ -27,7 +27,7 @@
                     (is (or (== @x 1) (== @x 2)))
                     (if (== @x 2)
                       (done)
-                      (swap! x inc))))]
+                      (is (== 2 (swap! x inc))))))]
     (async done
       (t/render [f-state done]))))
 
@@ -47,7 +47,7 @@
                 (let [ref (core/ref 1)]
                   (is (instance? hooks/RefHook ref))
                   (is (== @ref 1))
-                  (swap! ref inc)
+                  (is (== 2 (swap! ref inc)))
                   (is (== @ref 2))
                   (done)))]
     (async done


### PR DESCRIPTION
Fixes an inconsistency between the StateHook / RefHook / Cursor behavior
compared to atoms.

`swap!` and `reset!` now return the new value, as opposed to `nil`.