### PR TITLE
Fixes uix under native image

### DIFF
--- a/core/src/uix/compiler/alpha.clj
+++ b/core/src/uix/compiler/alpha.clj
@@ -515,22 +515,22 @@
     :nop))
 
 (defn render-to-string [src]
-  (let [sb (make-static-builder)
+  (let [^StaticBuilder sb (make-static-builder)
         state (volatile! :state/root)]
     (-render-html src state sb)
     (str (.sb sb))))
 
 (defn render-to-static-markup [src]
-  (let [sb (make-static-builder)]
+  (let [^StaticBuilder sb (make-static-builder)]
     (-render-html src (volatile! :state/static) sb)
     (str (.sb sb))))
 
 (defn render-to-stream [src {:keys [on-chunk]}]
-  (let [sb (make-stream-builder on-chunk)
+  (let [^StreamBuilder sb (make-stream-builder on-chunk)
         state (volatile! :state/root)]
     (-render-html src state sb)))
 
 (defn render-to-static-stream [src {:keys [on-chunk]}]
-  (let [sb (make-stream-builder on-chunk)
+  (let [^StreamBuilder sb (make-stream-builder on-chunk)
         state (volatile! :state/static)]
     (-render-html src state sb)))


### PR DESCRIPTION
Using uix with graalvm native image gives the following error:

```
Exception in thread "main" java.lang.IllegalArgumentException: No matching field found: sb for class uix.compiler.alpha.StaticBuilder
	at clojure.lang.Reflector.getInstanceField(Reflector.java:397)
	at clojure.lang.Reflector.invokeNoArgInstanceMember(Reflector.java:440)
	at uix.compiler.alpha$render_to_string.invokeStatic(alpha.clj:521)
	at uix.dom.alpha$render_to_string.invokeStatic(alpha.cljc:66)
	at datalite.core$_main.invokeStatic(core.clj:721)
	at datalite.core$_main.doInvoke(core.clj:721)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at datalite.core.main(Unknown Source)
```

