### PR TITLE
Fully qualify the uix.core deps

### DIFF
--- a/dom/deps.edn
+++ b/dom/deps.edn
@@ -2,10 +2,10 @@
         org.clojure/clojurescript {:mvn/version "1.10.739"}
         cljsjs/react-dom {:mvn/version "16.13.1-0"
                           :exclusions [cljsjs/react-dom-server]}
-        uix.core {:git/url "https://github.com/roman01la/uix.git"
-                  :deps/root "core"
-                  :sha "aea4812fba8c2274a186e0e2971bec12378ea19c"}}
+        uix.core/uix.core {:git/url "https://github.com/roman01la/uix.git"
+                           :deps/root "core"
+                           :sha "aea4812fba8c2274a186e0e2971bec12378ea19c"}}
  :paths ["src"]
- :aliases {:dev {:extra-deps {uix.core {:local/root "../core"}}}
+ :aliases {:dev {:extra-deps {uix.core/uix.core {:local/root "../core"}}}
            :release {:extra-deps {appliedscience/deps-library {:mvn/version "0.3.4"}}
                      :main-opts ["-m" "deps-library.release"]}}}

--- a/rn/deps.edn
+++ b/rn/deps.edn
@@ -1,9 +1,9 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.0"}
         org.clojure/clojurescript {:mvn/version "1.10.739"}
-        uix.core {:git/url "https://github.com/roman01la/uix.git"
-                  :deps/root "core"
-                  :sha "aea4812fba8c2274a186e0e2971bec12378ea19c"}}
+        uix.core/uix.core {:git/url "https://github.com/roman01la/uix.git"
+                           :deps/root "core"
+                           :sha "aea4812fba8c2274a186e0e2971bec12378ea19c"}}
  :paths ["src"]
- :aliases {:dev {:extra-deps {uix.core {:local/root "../core"}}}
+ :aliases {:dev {:extra-deps {uix.core/uix.core {:local/root "../core"}}}
            :release {:extra-deps {appliedscience/deps-library {:mvn/version "0.3.4"}}
                      :main-opts ["-m" "deps-library.release"]}}}


### PR DESCRIPTION
#63  had fully qualified the deps in `core/deps.edn`, but `dom/deps.edn` and `rn/deps.edn` still had unqualified deps leading to warnings like:
```
DEPRECATED: Libs must be qualified, change uix.core => uix.core/uix.core 
```